### PR TITLE
Update for new versions: Symfony 2.4.2, PHP 5.5.10, Zend Opcache 7.0.3

### DIFF
--- a/Resources/views/Collector/opcache.html.twig
+++ b/Resources/views/Collector/opcache.html.twig
@@ -142,7 +142,17 @@
         {% for key, value in collector.ini %}
         <tr>
             <td>{{ key }}</td>
-            <td>{% if value == false %}0{% else %}{{ value }}{% endif %}</td>
+            <td>
+                {% if value == false %}
+                    0
+                {% elseif key == 'opcache.memory_consumption' %}
+                    {{ '%.1f'|format(value / 1024 / 1024) }} MB
+                {% elseif key == 'opcache.max_wasted_percentage' %}
+                    {{ value * 100 ~ '%' }}
+                {% else %}
+                    {{ value }}
+                {% endif %}
+            </td>
         </tr>
         {% endfor %}
     </table>

--- a/Resources/views/Collector/opcache.html.twig
+++ b/Resources/views/Collector/opcache.html.twig
@@ -65,7 +65,7 @@
         <tr>
             <th>Key</th>
             <th>Size</th>
-            <th>Parcent</th>
+            <th>Percent</th>
         </tr>
 
         <tr>

--- a/Resources/views/Collector/opcache.html.twig
+++ b/Resources/views/Collector/opcache.html.twig
@@ -54,9 +54,9 @@
             <th>Cache Filled</th>
             <td>{{ collector.status.cache_full ? 'true' : 'false' }}</td>
         </tr>
+            <th>Cached Scripts</th>
+            <td>{{ collector.stats.num_cached_scripts }}</td>
         <tr>
-            <th>Cached Scripts (num/max)</th>
-            <td>{{ collector.stats.num_cached_scripts }}/{{ collector.stats.max_cached_scripts }}</td>
         </tr>
     </table>
 

--- a/Resources/views/Collector/opcache.html.twig
+++ b/Resources/views/Collector/opcache.html.twig
@@ -54,9 +54,42 @@
             <th>Cache Filled</th>
             <td>{{ collector.status.cache_full ? 'true' : 'false' }}</td>
         </tr>
+    </table>
+
+    <h2>Cache Statistics</h2>
+    <table>
+        <tr>
+            <th>Key</th>
+            <th>Value</th>
+        </tr>
+        <tr>
             <th>Cached Scripts</th>
             <td>{{ collector.stats.num_cached_scripts }}</td>
+        </tr>
         <tr>
+            <th>Cached Keys</th>
+            <td>{{ collector.stats.num_cached_keys }}/{{ collector.stats.max_cached_keys }}</td>
+        </tr>
+        <tr>
+            <th>Start Time</th>
+            <td>{{ collector.stats.start_time|date('Y-m-d H:i:s') }}</td>
+        </tr>
+        <tr>
+            <th>Start Time</th>
+            {% set last_restart_time = collector.stats.last_restart_time %}
+            <td>{{ last_restart_time ? last_restart_time|date('Y-m-d H:i:s') : last_restart_time }}</td>
+        </tr>
+        <tr>
+            <th>OOM Restarts</th>
+            <td>{{ collector.stats.oom_restarts }}</td>
+        </tr>
+        <tr>
+            <th>Hash Restarts</th>
+            <td>{{ collector.stats.hash_restarts }}</td>
+        </tr>
+        <tr>
+            <th>Manual Restarts</th>
+            <td>{{ collector.stats.manual_restarts }}</td>
         </tr>
     </table>
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.0,<2.3-dev"
+        "symfony/framework-bundle": ">=2.0"
     },
     "autoload": {
         "psr-0": { "Codepoet\\OpcacheProfilerBundle": "" }


### PR DESCRIPTION
I couldn't pop your bundle in because of the <2.3-dev restriction.  I removed the restriction and the bundle composed in nicely.

Additional updates:
1) I removed `{{ collector.stats.max_cached_scripts }}` as it appears not to exist and caused a twig compilation error.
2) Changed typo: "Parcent" to "Percent"
3) Added some extra stats that were available but not shown
4) Touched up the formatting opcache.memory_consumption and opcache.max_wasted_percentage

I only tested this on the configuration in the title, no other environments.  Works for me, so if you don't want to merge it for any reason, I can continue using the fork I made.  Thanks!
